### PR TITLE
Allow setting nil on `AndroidUserDefaults`

### DIFF
--- a/Sources/SkipAndroidSDKBridge/AndroidContext.swift
+++ b/Sources/SkipAndroidSDKBridge/AndroidContext.swift
@@ -54,11 +54,11 @@ public class AndroidUserDefaults {
         self.userDefaults = userDefaults
     }
 
-    public func setDouble(_ value: Double, forKey defaultName: String) {
+    public func setDouble(_ value: Double?, forKey defaultName: String) {
         userDefaults.set(value, forKey: defaultName)
     }
 
-    public func double(forKey defaultName: String) -> Double {
+    public func double(forKey defaultName: String) -> Double? {
         userDefaults.double(forKey: defaultName)
     }
 
@@ -71,19 +71,19 @@ public class AndroidUserDefaults {
 //        userDefaults.float(forKey: defaultName)
 //    }
 
-    public func setBool(_ value: Bool, forKey defaultName: String) {
+    public func setBool(_ value: Bool?, forKey defaultName: String) {
         userDefaults.set(value, forKey: defaultName)
     }
 
-    public func bool(forKey defaultName: String) -> Bool {
+    public func bool(forKey defaultName: String) -> Bool? {
         userDefaults.bool(forKey: defaultName)
     }
 
-    public func setInt(_ value: Int, forKey defaultName: String) {
+    public func setInt(_ value: Int?, forKey defaultName: String) {
         userDefaults.set(value, forKey: defaultName)
     }
 
-    public func integer(forKey defaultName: String) -> Int {
+    public func integer(forKey defaultName: String) -> Int? {
         userDefaults.integer(forKey: defaultName)
     }
 


### PR DESCRIPTION
Allows setting nil on `AndroidUserDefaults`, making sure you can delete the values stored.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

