### PR TITLE
Remove skip-fuse Observation Bridging

### DIFF
--- a/Sources/SkipAndroidBridge/Observation.swift
+++ b/Sources/SkipAndroidBridge/Observation.swift
@@ -20,12 +20,12 @@ public struct Observation {
         }
 
         public func access<Subject, Member>(_ subject: Subject, keyPath: KeyPath<Subject, Member>) where Subject : Observable {
-            bridgeSupport.access(subject, keyPath: keyPath)
+//            bridgeSupport.access(subject, keyPath: keyPath)
             registrar.access(subject, keyPath: keyPath)
         }
 
         public func willSet<Subject, Member>(_ subject: Subject, keyPath: KeyPath<Subject, Member>) where Subject : Observable {
-            bridgeSupport.willSet(subject, keyPath: keyPath)
+//            bridgeSupport.willSet(subject, keyPath: keyPath)
             registrar.willSet(subject, keyPath: keyPath)
         }
 
@@ -34,7 +34,7 @@ public struct Observation {
         }
 
         public func withMutation<Subject, Member, T>(of subject: Subject, keyPath: KeyPath<Subject, Member>, _ mutation: () throws -> T) rethrows -> T where Subject : Observable {
-            bridgeSupport.willSet(subject, keyPath: keyPath)
+//            bridgeSupport.willSet(subject, keyPath: keyPath)
             return try registrar.withMutation(of: subject, keyPath: keyPath, mutation)
         }
 


### PR DESCRIPTION
Disable bridge observation registration to skip-fuse

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

