### PR TITLE
Support linux-gnu host compilation for skip export

### DIFF
--- a/Sources/SkipAndroidBridge/AndroidBridgeBootstrap.swift
+++ b/Sources/SkipAndroidBridge/AndroidBridgeBootstrap.swift
@@ -16,6 +16,16 @@ import Foundation
 @_exported import AndroidLogging
 #elseif canImport(OSLog)
 @_exported import OSLog
+#else
+/// Compile-only Logger shim for non-Android Linux hosts (skip export host pass).
+public struct Logger: Sendable {
+    public init(subsystem: String, category: String) {}
+    public func debug(_ message: String) {}
+    public func info(_ message: String) {}
+    public func warning(_ message: String) {}
+    public func error(_ message: String) {}
+    public func log(_ message: String) {}
+}
 #endif
 #if canImport(AndroidLooper)
 @_exported import AndroidLooper
@@ -127,7 +137,7 @@ private func bootstrapFileManagerProperties(filesDir: String, cacheDir: String) 
 }
 
 // URL.applicationSupportDirectory exists in Darwin's Foundation but not in Android's Foundation
-#if os(Android)
+#if os(Android) || os(Linux)
 // SKIP @nobridge
 extension URL {
     public static var applicationSupportDirectory: URL {

--- a/Sources/SkipAndroidBridge/AndroidBundle.swift
+++ b/Sources/SkipAndroidBridge/AndroidBundle.swift
@@ -4,6 +4,7 @@ import Foundation
 #if os(Android) || ROBOLECTRIC
 import SwiftJNI // for isJNIInitialized (no-JVM fallback in the bundle path)
 #endif
+#if os(Android) || ROBOLECTRIC || canImport(Darwin)
 
 /// Override of native `Bundle` for Android that delegates to our `skip.foundation.Bundle` Kotlin object.
 open class AndroidBundle : Foundation.Bundle, @unchecked Sendable {
@@ -574,5 +575,6 @@ public func NSLocalizedStringAccess(_ key: String, tableName: String? = nil, bun
     return NSLocalizedString(key, tableName: tableName, bundle: bundle?.bundle, value: value, comment: comment)
 }
 
+#endif
 #endif
 #endif

--- a/Sources/SkipAndroidBridge/AndroidLocalizedStringResource.swift
+++ b/Sources/SkipAndroidBridge/AndroidLocalizedStringResource.swift
@@ -32,9 +32,11 @@ public struct AndroidLocalizedStringResource : /* Codable, */ ExpressibleByStrin
         self._bundle = bundle
     }
 
+#if os(Android) || ROBOLECTRIC || canImport(Darwin)
     public init(_ key: StaticString, defaultValue: AndroidStringInterpolation, table: String? = nil, locale: Locale? = nil, bundle: AndroidBundle, comment: StaticString? = nil) {
         self.init(key, defaultValue: defaultValue, table: table, locale: locale, bundle: BundleDescription.from(bundle: bundle), comment: comment)
     }
+#endif
 
     public init(_ keyAndValue: AndroidStringInterpolation, table: String? = nil, locale: Locale? = nil, bundle: BundleDescription? = nil, comment: StaticString? = nil) {
         self._key = nil
@@ -44,9 +46,11 @@ public struct AndroidLocalizedStringResource : /* Codable, */ ExpressibleByStrin
         self._bundle = bundle
     }
 
+#if os(Android) || ROBOLECTRIC || canImport(Darwin)
     public init(_ keyAndValue: AndroidStringInterpolation, table: String? = nil, locale: Locale? = nil, bundle: AndroidBundle, comment: StaticString? = nil) {
         self.init(keyAndValue, table: table, locale: locale, bundle: BundleDescription.from(bundle: bundle), comment: comment)
     }
+#endif
 
     public init(stringLiteral: String) {
         self._key = nil


### PR DESCRIPTION
## Motivation

We run `skip export` (Fuse framework → AARs) in CI on **Linux** runners. The export's host-platform `swift build` (`x86_64-unknown-linux-gnu`) — where the skipstone plugin does its transpile/bridging analysis — must compile the whole dependency graph, including this package's non-Android branch. That branch currently assumes Darwin, so the export fails on a Linux host with:

- `Logger` unresolved (neither `AndroidLogging` nor `OSLog` is importable on linux-gnu)
- `URL.applicationSupportDirectory` missing (not in Linux Foundation)
- `class AndroidBundle: Bundle` — Linux corelibs `Bundle` can't be subclassed
- the two `AndroidBundle`-typed convenience inits in `AndroidLocalizedStringResource`

## Changes

Four minimal, compile-scoping edits (one commit):

1. Compile-only `Logger` shim in the final `#else` of the AndroidLogging/OSLog import chain — only ever compiled on hosts with neither module, i.e. never on Android or Darwin.
2. `URL.applicationSupportDirectory` extension guard: `#if os(Android)` → `#if os(Android) || os(Linux)`.
3. `AndroidBundle.swift` scoped to `#if os(Android) || ROBOLECTRIC || canImport(Darwin)` — the platforms that actually use it.
4. The two `AndroidBundle` convenience inits in `AndroidLocalizedStringResource.swift` behind the same guard.

## Behavior

No change on Android or Darwin — every edit only alters what a linux-gnu host pass compiles. Verified:

- macOS `swift build`: green.
- A production app's CI has been running `skip export` on Linux with exactly these patches applied via `swift package edit` for the full pipeline (host build → transpile → AAR packaging → Android lint + unit tests): green across many runs.

Happy to adjust guard spelling/placement to match house style.
